### PR TITLE
Make RDCRunner capable of using targetEntity from the stdin-json

### DIFF
--- a/riscoss-rdc-api/src/main/java/eu/riscoss/rdc/RDCRunner.java
+++ b/riscoss-rdc-api/src/main/java/eu/riscoss/rdc/RDCRunner.java
@@ -72,18 +72,19 @@ public class RDCRunner {
 			return;
 		}
 		
-		String entity = m.get( "-entity" );
-		if( entity == null ) {
-			printUsage();
-			return;
-		}
-		
 		JSONObject input = null;;
 		if( args.length > 0 && "--stdin-conf".equals(args[ args.length - 1] ) ) {
 			String stdin = IOUtils.toString(System.in, "UTF-8");
 			input = new JSONObject(stdin);
 		} else {
 			input = new JSONObject();
+		}
+
+		String entity = m.get( "-entity" );
+		if( entity == null ) { entity = input.optString("targetEntity"); }
+		if( entity == null ) {
+			printUsage();
+			return;
 		}
 		
 		RDC rdc = null;


### PR DESCRIPTION
This is a small change which should have no functional effect on the behavior of the data collector but makes `-entity` specifiable from the json stdin key: `targetEntity`.